### PR TITLE
Promise<T>|T -> Promise<T>

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,5 @@
 // Preliminary TS definitions
-type HandlerCallback = (req: Request) => Promise<Response> | Response;
+type HandlerCallback = (req: Request) => Promise<Response>;
 type Condition = (req: Request) => boolean;
 interface Route {
 	conditions: Condition | Array<Condition>;


### PR DESCRIPTION
Huge nit, but `Promise<T>|T` holds no more information than `Promise<T>` because `Promise<T>` effectively subsumes `T`, you can always await a non-promise and construct a promise from a non-promise in TS. Bit easier to understand why with the generated code: https://www.typescriptlang.org/play?target=3#code/C4TwDgpgBAglC8UAKAnA9gWwJYGcIB4A7AVwwCMIUA+AHxPMoG4AoZgM2MIGNgs1CobABQBKAFywoAbxQRgxFAICMjAL6sAhjhDdBnHnwFlR05lHNQu-HMCgaEg0SwuXraADYQAdO7QBzIQ0Adw0sW2ERERZ1YyigA