### PR TITLE
Should Fix #1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,5 +16,7 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           secrets: |
               SECRET_KEY
+              SLACK_SIGNING_SECRET
         env:
             SECRET_KEY: ${{ secrets.SECRET_KEY }}
+            SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,10 +30,14 @@ export const validSlackRequest = async (request: Request): Promise<boolean> => {
 		)
 
 		if (version && slackSignature) {
-			const signatureUint8 = encoder.encode(slackSignature)
+			// Convert hex digest to Uint8Array
+			const signatureUint8 = new Uint8Array(slackSignature.length / 2);
+			for(let i = 0; i < slackSignature.length; i += 2) {
+				signatureUint8[i / 2] = parseInt(slackSignature.slice(i, i + 2), 16);
+			}
+
 			// We want to verify that hte slack signature matches what we hash with the key we made
 			const result = await crypto.subtle.verify({name: "HMAC", hash: "SHA-256"}, key, signatureUint8, msgUint8);
-			console.log(slackSignature)
 			return result;
 		}
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,7 +7,7 @@ export const validSlackRequest = async (request: Request): Promise<boolean> => {
 
 		// Protect against replay attacks by checking if it's a request that's older than 5 minutes
 		if (
-			timestamp &&
+			!timestamp ||
 			Date.now() - new Date(timestamp).getTime() > 5 * 60 * 1000
 		) {
 			throw new Error('The request is old.');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -36,7 +36,7 @@ export const validSlackRequest = async (request: Request): Promise<boolean> => {
 				signatureUint8[i / 2] = parseInt(slackSignature.slice(i, i + 2), 16);
 			}
 
-			// We want to verify that hte slack signature matches what we hash with the key we made
+			// We want to verify that the slack signature matches what we hash with the key we made
 			const result = await crypto.subtle.verify({name: "HMAC", hash: "SHA-256"}, key, signatureUint8, msgUint8);
 			return result;
 		}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 export const validSlackRequest = async (request: Request): Promise<boolean> => {
 	try {
 		// Grab raw body
-		const requestBody = await request.text();
+		const requestBody = await request.clone().text(); // Have to clone since body can only be read once
 		const timestamp = request.headers.get('X-Slack-Request-Timestamp');
 		const [version, slackSignature] = request.headers.get('X-Slack-Signature')?.split("=") as String[];
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 export const validSlackRequest = async (request: Request): Promise<boolean> => {
 	try {
 		// Grab raw body
-		const requestBody = request.body;
+		const requestBody = await request.text();
 		const timestamp = request.headers.get('X-Slack-Request-Timestamp');
 
 		// Protect against replay attacks by checking if it's a request that's older than 5 minutes


### PR DESCRIPTION
I think I've fixed #1. There were 2 things that I had to change.

One was that doing `request.body` didn't actually get the body, but instead returned some `ReadableStream` object. Using `text()` got what we wanted.

The second was that `slackSignature` wasn't converted to a `Uint8Array` properly. The old approach using a utf8 encoder, which was what we needed for the `sigBasestring`, but `slackSignature` should be interpreted as a string of consecutive hex numbers. I couldn't find a prebuilt function to do that without having to add the node types, so I just used a loop for the conversion.

However, although the verification seems to work, the actual shorten request always times out. I think it's just because my cf worker is misconfigured since this happens even if I comment out the verification part.